### PR TITLE
Fix warnings

### DIFF
--- a/src/adapters.rs
+++ b/src/adapters.rs
@@ -1,6 +1,6 @@
 // Hexagonal architecture: Wallet adapter implementation
 use crate::ports::{WalletPort, Transaction};
-use anya_core::bitcoin::wallet::{Wallet as CoreWallet, WalletConfig, AddressType, BalanceManager, TransactionManager, WalletType, CoinSelectionStrategy, FeeStrategy, WalletError, AddressManager, transactions};
+use anya_core::bitcoin::wallet::{Wallet as CoreWallet, WalletConfig, AddressType, BalanceManager, TransactionManager, WalletType, CoinSelectionStrategy, FeeStrategy, AddressManager, transactions};
 use anya_core::bitcoin::interface::BitcoinInterface;
 use anya_core::bitcoin::Network;
 use std::sync::Arc;
@@ -32,13 +32,6 @@ impl WalletAdapter {
         // The bitcoin_client should implement BitcoinInterface, but for now use None
         let bitcoin_client: Option<Arc<dyn BitcoinInterface>> = None;
         Self { inner: CoreWallet::new(config, bitcoin_client) }
-    }
-
-    // Helper function to get the last error from anya_core (if available)
-    fn last_error(&self) -> Option<WalletError> {
-        // This is a placeholder. You would need to expose a way to get the last error from anya_core
-        // For now, we'll assume anya_core returns errors directly from the methods.
-        None
     }
 }
 

--- a/src/components/send_screen.rs
+++ b/src/components/send_screen.rs
@@ -1,8 +1,6 @@
 use dioxus::prelude::*;
 use crate::adapters::WalletAdapter;
 use crate::ports::WalletPort;
-use anya_core::bitcoin::Address;
-use std::str::FromStr;
 
 #[component]
 pub fn SendScreen(wallet: Signal<Box<WalletAdapter>>) -> Element {


### PR DESCRIPTION
This pull request makes adjustments to the `WalletAdapter` implementation and its usage, focusing on simplifying the codebase by removing unused functionality and redundant imports.

### Codebase simplification:

* Removed the unused `WalletError` type import from `anya_core::bitcoin::wallet` in `src/adapters.rs`. This import was no longer necessary after removing the `last_error` helper function.
* Deleted the `last_error` helper function from the `WalletAdapter` implementation in `src/adapters.rs`. This function was a placeholder and not actively used in the codebase.

### Cleanup of unused imports:

* Removed unused imports `anya_core::bitcoin::Address` and `std::str::FromStr` from `src/components/send_screen.rs`, as they were not referenced in the file.